### PR TITLE
Add link to mappings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -264,7 +264,7 @@ iframe {
   function load_new_url(new_url) {
     $('#new_url').val(new_url);
     $('#new iframe').attr('src', new_url);
-    $("a#transition_mapping").attr("href", function(i, href) {
+    $("a#edit_mapping_link").attr("href", function(i, href) {
       if (href.match("http://aka")) {
         return href.replace(href.split("=")[1], new_url);
       } else {


### PR DESCRIPTION
_Please do not deploy this until the code in https://github.com/alphagov/transition/commit/67bac50c31a17d9fb74013743b011a0a1c31f2e7 has been deployed._

As per https://www.pivotaltracker.com/story/show/64748980, this creates a link on the header of the side-by-side browser for users to be able to edit the mapping they're looking at.
