### PR TITLE
Make the 'Edit this mapping' link open in new tab

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -172,7 +172,7 @@ iframe {
                 <a href="/__/">Explore</a> the <span id="origin"></span> <a href="https://www.gov.uk">GOV.UK</a> mappings
         </h1>
         <h1>
-          <a id="edit_mapping_link" href="https://transition.production.alphagov.co.uk/mappings/find_global?url=">Edit this mapping</a>
+          <a id="edit_mapping_link" target="_blank" href="https://transition.production.alphagov.co.uk/mappings/find_global?url=">Edit this mapping</a>
         </h1>
   </div>
   <div class="panes">


### PR DESCRIPTION
Otherwise a user will have to go back several times to get back to
where they were in the side-by-side browser after editing or adding
a mapping.
