### PR TITLE
Style header links and clarify mapping edit link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -47,13 +47,16 @@ body {
 
 .header a {
         color: white;
-        text-decoration: none;
         font-weight: normal;
 }
 
 .header a:hover {
         color: white;
         text-decoration: underline;
+}
+
+.header .header-secondary-link {
+        color: #aaa;
 }
 
 .welcome {
@@ -172,7 +175,7 @@ iframe {
                 <a href="/__/">Explore</a> the <span id="origin"></span> <a href="https://www.gov.uk">GOV.UK</a> mappings
         </h1>
         <h1>
-          <a id="edit_mapping_link" target="_blank" href="https://transition.production.alphagov.co.uk/mappings/find_global?url=">Edit this mapping</a>
+          <a id="edit_mapping_link" class="header-secondary-link" target="_blank" title="Link will open in a new window" href="https://transition.production.alphagov.co.uk/mappings/find_global?url=">Edit mapping in Transition</a>
         </h1>
   </div>
   <div class="panes">


### PR DESCRIPTION
- underline links
- visually separate the edit mapping link from the rest of the
  header text
- add title to the edit mapping link to make it clearer that it will
  open in a new window

Mostly the result of suggestions made by @fofr after discussion of https://github.com/alphagov/side-by-side-browser/pull/6.
