### PR TITLE
Remove references to `managed_by_transition`

### DIFF
--- a/etc/hosts.json
+++ b/etc/hosts.json
@@ -1,15 +1,12 @@
 {
   "results":[
     {
-      "managed_by_transition" : true,
       "hostname" : "www.ukba.homeoffice.gov.uk"
     },
     {
-      "managed_by_transition" : false,
       "hostname" : "www.bis.gov.uk"
     },
     {
-      "managed_by_transition" : true,
       "hostname" : "www.environment-agency.gov.uk"
     }
   ]

--- a/test/fixtures/hosts.json
+++ b/test/fixtures/hosts.json
@@ -1,19 +1,15 @@
 {
   "results":[
     {
-      "managed_by_transition" : false,
       "hostname" : "aka.example.com"
     },
     {
-      "managed_by_transition" : false,
       "hostname" : "foo.example.com"
     },
     {
-      "managed_by_transition" : false,
       "hostname" : "bar.example.com"
     },
     {
-      "managed_by_transition" : false,
       "hostname" : "aka-foo.example.com"
     }
   ]


### PR DESCRIPTION
- Redirector is dead, everything is managed by transition now.
- This relates to https://github.com/alphagov/transition/pull/413. I'm not sure if merge order matters?
