### PR TITLE
Remove references to private-frontend

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -276,10 +276,10 @@ iframe {
     });
 
     // warn about awaiting publication
-    if (new_url.match(/^https:\/\/private-frontend/)) {
-        $('#awaiting-publication').show();
+    if (new_url.match(/^https:\/\/draft-origin/)) {
+      $('#awaiting-publication').show();
     } else {
-        $('#awaiting-publication').hide();
+      $('#awaiting-publication').hide();
     }
   }
 


### PR DESCRIPTION
Private-frontend is being turned off, so we change the reference to it to
draft-origin instead, as this provides the new preview functionality.

[Trello](https://trello.com/c/JYT9roQm/709-turn-off-private-frontend)