### PR TITLE
Update xip.io to nip.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Proxy a web site to preview redirections ahead of it being transitioned to GOV.U
 
     $ node server.js
 
-...then you can use [xip.io](http://xip.io/) to make it work with localhost, eg:
+...then you can use [nip.io](http://xip.io/) to make it work with localhost, eg:
 
-http://www.justice.gov.uk.side-by-side.127.0.0.1.xip.io:3023/__/#/
+http://www.justice.gov.uk.side-by-side.127.0.0.1.nip.io:3023/__/#/
 
 ## Installation
 


### PR DESCRIPTION
The xip.io homepage is currently blocked at GDS. You can, however still
use it as per the docs to view the side by side browser when doing
development. Nip.io seems to be a drop in replacement that isn't
blocked.

Update the documentation so that developers who aren't familiar with
xip.io don't get roadblocked when they curiously click on the link in
the documentation.