### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      # Framework gems
+      - dependency-name: chai
+        dependency-type: direct
+      - dependency-name: mocha
+        dependency-type: direct


### PR DESCRIPTION
In accordance with [RFC 126], we're configuring Dependabot to only
raise Pull Requests for the following three categories:

1. Security updates
2. Internal libraries
3. Framework libraries

Things have moved on slightly since the RFC; we're now using
[GitHub native] configs rather than the legacy `.dependabot`
approach. The syntax is slightly different to the example config
provided in the RFC but most of it is easily transferable.

We've handled (2) and (3) in config, and have set it to only raise
PRs for direct updates, i.e. updates to subdependencies of the
named dependencies will not raise PRs.

We've chosen a `govuk*` wildcard to cover things like
`gds-api-adapters` and `govuk_app_config` and other unknown future
dependencies. Having `govuk` as a [suffix is not encouraged][wildcards]
so instead of a `*govuk` wildcard we've named `rubocop-govuk`
explicitly. We explicitly name dependencies beginning with `gds`
[for the same reason][discussion].

Trello: https://trello.com/c/uPoriyfJ/2049-add-dependabot-configuration-to-each-repo-blitz-pair

[discussion]: https://github.com/alphagov/content-store/pull/750#discussion_r454208436
[GitHub native]: https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates
[security]: https://github.community/t/how-to-get-dependabot-to-trigger-for-security-updates-only/117257/5
[RFC 126]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-126-custom-configuration-for-dependabot.md
[wildcards]: https://github.com/alphagov/content-store/pull/750#discussion_r453693082