### PR TITLE
Remove allow list from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,3 @@ updates:
     directory: /
     schedule:
       interval: daily
-    allow:
-      # Framework gems
-      - dependency-name: chai
-        dependency-type: direct
-      - dependency-name: mocha
-        dependency-type: direct


### PR DESCRIPTION
Trello card: https://trello.com/c/DuA0q9Ck/2966-remove-allow-lists-from-dependabot-configs-2